### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,23 +11,23 @@
     :target: http://multipla.readthedocs.org/en/latest/
     :alt: Read the Docs
 
-.. image:: https://pypip.in/download/multipla/badge.svg?period=month
+.. image:: https://img.shields.io/pypi/dm/multipla.svg
     :target: https://pypi.python.org/pypi/multipla/
     :alt: Downloads
 
-.. image:: https://pypip.in/version/multipla/badge.svg?text=latest
+.. image:: https://img.shields.io/pypi/v/multipla.svg?label=latest
     :target: https://pypi.python.org/pypi/multipla/
     :alt: Latest Version
 
-.. image:: https://pypip.in/status/multipla/badge.svg
+.. image:: https://img.shields.io/pypi/status/multipla.svg
     :target: https://pypi.python.org/pypi/multipla/
     :alt: Development Status
 
-.. image:: https://pypip.in/py_versions/multipla/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/multipla.svg
     :target: https://pypi.python.org/pypi/multipla/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/implementation/multipla/badge.svg
+.. image:: https://img.shields.io/pypi/implementation/multipla.svg
     :target: https://pypi.python.org/pypi/multipla/
     :alt: Supported Python implementations
 
@@ -35,11 +35,11 @@
     :target: https://pypi.python.org/pypi/multipla/
     :alt: Egg Status
 
-.. image:: https://pypip.in/wheel/multipla/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/multipla.svg
     :target: https://pypi.python.org/pypi/multipla/
     :alt: Wheel Status
 
-.. .. image:: https://pypip.in/license/multipla/badge.svg
+.. .. image:: https://img.shields.io/pypi/l/multipla.svg
 ..     :target: https://pypi.python.org/pypi/multipla/
 ..     :alt: License
 .. 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20multipla))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `multipla`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.